### PR TITLE
Add MASS to allow importing package

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -4,7 +4,7 @@ Date: 2022-11-28
 Title: Statistical methods for the agricultural sciences
 Author: Andrea Onofri <andrea.onofri@unipg.it>
 Maintainer: Andrea Onofri <onofri@unipg.it>
-Depends: R (>= 4.0.2), drc, plyr, car, multcompView
+Depends: R (>= 4.0.2), MASS, drc, plyr, car, multcompView
 Description: This package contains several service functions to be used to analyse datasets obtained from field experiments or other types of assays in agriculture
 URL: https://www.statforbiology.com
 License: GPL (>= 2)

--- a/NAMESPACE
+++ b/NAMESPACE
@@ -3,6 +3,7 @@ importFrom(utils, tail)
 importFrom(car, deltaMethod)
 importFrom(plyr, ldply, ddply)
 importFrom(multcompView, multcompLetters3)
+import(MASS)
 import(stats)
 export(angularTransform, ma, 
        linear.fun, NLS.linear, DRC.linear,


### PR DESCRIPTION
I'm including your package in a package I created. My package won't build because `aomisc` is looking for `boxcox`, which appears as an error when building `aomisc`. I added MASS to the imports to resolve the error.